### PR TITLE
fix: Point coveralls gem to patch version which handles TLS 1.2

### DIFF
--- a/coveralls-multi.gemspec
+++ b/coveralls-multi.gemspec
@@ -20,12 +20,12 @@ Gem::Specification.new do |spec|
   spec.executables   = 'coveralls-multi'
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'coveralls', '~> 0.8.21'
+  spec.add_dependency 'coveralls-revelry', '~> 0.8.23'
   spec.add_dependency 'coveralls-lcov', '~> 1.5.1'
 
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'pry', '~> 0.11.3'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'simplecov', '~> 0.14.1'
+  spec.add_development_dependency 'simplecov', '~> 0.16.1'
 end


### PR DESCRIPTION
Fixes limitation where gem won't accept alternate TLS versions by using the revelry-forked version of coveralls-ruby.